### PR TITLE
Benchmark output

### DIFF
--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -11,7 +11,8 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const 
                                  const uint32_t init_data_preparation_cores, const uint32_t init_clients,
                                  const bool init_enable_visualization, const bool init_verify,
                                  const bool init_cache_binary_tables, const bool init_metrics,
-                                 const bool init_enable_temporary_memory_tracking)
+                                 const bool init_enable_temporary_memory_tracking, 
+                                 const std::optional<std::string>& init_memory_tracking_output_file_path)
     : benchmark_mode(init_benchmark_mode),
       chunk_size(init_chunk_size),
       encoding_config(init_encoding_config),
@@ -28,7 +29,8 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const 
       verify(init_verify),
       cache_binary_tables(init_cache_binary_tables),
       metrics(init_metrics),
-      enable_temporary_memory_tracking(init_enable_temporary_memory_tracking) {}
+      enable_temporary_memory_tracking(init_enable_temporary_memory_tracking),
+      memory_tracking_output_file_path(init_memory_tracking_output_file_path) {}
 
 BenchmarkConfig BenchmarkConfig::get_default_config() {
   return BenchmarkConfig();

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -25,7 +25,8 @@ class BenchmarkConfig {
                   const std::optional<std::string>& init_output_file_path, const bool init_enable_scheduler,
                   const uint32_t init_cores, const uint32_t init_data_preparation_cores, const uint32_t init_clients,
                   const bool init_enable_visualization, const bool init_verify, const bool init_cache_binary_tables,
-                  const bool init_metrics, const bool init_enable_temporary_memory_tracking);
+                  const bool init_metrics, const bool init_enable_temporary_memory_tracking,
+                  const std::optional<std::string>& init_memory_tracking_output_file_path);
 
   static BenchmarkConfig get_default_config();
 
@@ -46,6 +47,7 @@ class BenchmarkConfig {
   bool cache_binary_tables = false;  // Defaults to false for internal use, but the CLI sets it to true by default
   bool metrics = false;
   bool enable_temporary_memory_tracking = false;
+  std::optional<std::string> memory_tracking_output_file_path = std::nullopt;
 
  private:
   BenchmarkConfig() = default;

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -19,6 +19,7 @@
 #include "sql/sql_pipeline_builder.hpp"
 #include "storage/chunk.hpp"
 #include "tpch/tpch_table_generator.hpp"
+#include "utils/meta_tables/meta_temporary_memory_usage_table.hpp"
 #include "utils/format_duration.hpp"
 #include "utils/sqlite_wrapper.hpp"
 #include "utils/timer.hpp"
@@ -479,7 +480,8 @@ void BenchmarkRunner::write_report_to_file() const {
 }
 
 void BenchmarkRunner::write_temporary_memory_usage_report_to_file() const {
-  std::cout << "SHOULD WRITE REPORT TO FILE " << *(_config.memory_tracking_output_file_path) << std::endl;
+  const auto report = _sql_to_json("SELECT * FROM meta_"+MetaTemporaryMemoryUsageTable().name());
+  std::ofstream{_config.memory_tracking_output_file_path.value()} << std::setw(2) << report << std::endl;
 }
 
 cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& benchmark_name) {
@@ -516,7 +518,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("memory_tracking", "Enables tracking of the temporary memory usage of certain operators using polymorphic allocators", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("memory_tracking_output", "JSON file to output temporary memory tracking results to, don't specify for stdout. Only applies if memory tracking is activated.", cxxopts::value<std::string>()->default_value("")) // NOLINT
+    ("memory_tracking_output", "JSON file to output temporary memory tracking results to, don't specify for no output. Only applies if memory tracking is activated.", cxxopts::value<std::string>()->default_value("")) // NOLINT
     ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("metrics", "Track more metrics (steps in SQL pipeline, system utilization, etc.) and add them to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")) // NOLINT
     // This option is only advised when the underlying system's memory capacity is overleaded by the preparation phase.

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -142,6 +142,9 @@ void BenchmarkRunner::run() {
   if (_config.output_file_path) {
     if (!_config.verify && !_config.enable_visualization) {
       write_report_to_file();
+      if (_config.enable_temporary_memory_tracking) {
+        write_temporary_memory_usage_report_to_file();
+      }
     } else {
       std::cout << "- Not writing JSON result as either verification or visualization are activated." << std::endl;
       std::cout << "  These options make the results meaningless." << std::endl;
@@ -475,6 +478,10 @@ void BenchmarkRunner::write_report_to_file() const {
   std::ofstream{_config.output_file_path.value()} << std::setw(2) << report << std::endl;
 }
 
+void BenchmarkRunner::write_temporary_memory_usage_report_to_file() const {
+  std::cout << "SHOULD WRITE REPORT TO FILE " << *(_config.memory_tracking_output_file_path) << std::endl;
+}
+
 cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& benchmark_name) {
   cxxopts::Options cli_options{benchmark_name};
 
@@ -509,6 +516,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("memory_tracking", "Enables tracking of the temporary memory usage of certain operators using polymorphic allocators", cxxopts::value<bool>()->default_value("false")) // NOLINT
+    ("memory_tracking_output", "JSON file to output temporary memory tracking results to, don't specify for stdout. Only applies if memory tracking is activated.", cxxopts::value<std::string>()->default_value("")) // NOLINT
     ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("metrics", "Track more metrics (steps in SQL pipeline, system utilization, etc.) and add them to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")) // NOLINT
     // This option is only advised when the underlying system's memory capacity is overleaded by the preparation phase.

--- a/src/benchmarklib/benchmark_runner.hpp
+++ b/src/benchmarklib/benchmark_runner.hpp
@@ -56,6 +56,9 @@ class BenchmarkRunner : public Noncopyable {
   // writing the file may affect the performance of concurrently running queries.
   void write_report_to_file() const;
 
+  // Create report of the temporary memory usage. This is essentially a dump of the temporary memory usage meta table.
+  void write_temporary_memory_usage_report_to_file() const;
+
  private:
   // Run benchmark in BenchmarkMode::Shuffled mode
   void _benchmark_shuffled();

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -151,7 +151,7 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
   if (!memory_tracking_output_file_string.empty()) {
     if (enable_temporary_memory_tracking) {
       memory_tracking_output_file_path = memory_tracking_output_file_string;
-      std::cout << "- Writing temporary memory usage stats results to '" << *memory_tracking_output_file_path << "'" << std::endl;
+      std::cout << "- Writing temporary memory usage stats results to '" << memory_tracking_output_file_path.value() << "'" << std::endl;
     } else {
       std::cout << "- CAUTION: you have specified an output file for the memory tracking results even though memory tracking is deactivated!" << std::endl;;
     }

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -141,9 +141,20 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
   const auto enable_temporary_memory_tracking = parse_result["memory_tracking"].as<bool>();
   if (enable_temporary_memory_tracking) {
     std::cout << "- Tracking temporary memory usage."
-              << "  Caution: Temporary memory usage tracking is not implemente for all operators" << std::endl;
+              << " Caution: Temporary memory usage tracking is not implemented for all operators" << std::endl; 
   } else {
     std::cout << "- Not tracking temporary memory usage" << std::endl;
+  }
+
+  std::optional<std::string> memory_tracking_output_file_path;
+  const auto memory_tracking_output_file_string = parse_result["memory_tracking_output"].as<std::string>();
+  if (!memory_tracking_output_file_string.empty()) {
+    if (enable_temporary_memory_tracking) {
+      memory_tracking_output_file_path = memory_tracking_output_file_string;
+      std::cout << "- Writing temporary memory usage stats results to '" << *memory_tracking_output_file_path << "'" << std::endl;
+    } else {
+      std::cout << "- CAUTION: you have specified an output file for the memory tracking results even though memory tracking is deactivated!" << std::endl;;
+    }
   }
 
   return BenchmarkConfig{benchmark_mode,
@@ -162,7 +173,8 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
                          verify,
                          cache_binary_tables,
                          metrics,
-                         enable_temporary_memory_tracking};
+                         enable_temporary_memory_tracking,
+                         memory_tracking_output_file_path};
 }
 
 EncodingConfig CLIConfigParser::parse_encoding_config(const std::string& encoding_file_str) {


### PR DESCRIPTION
closes #31 

Write the `meta_temporary_memory_usage` table to its own file at the end of a benchmark run. The cli argument `--memory_tracking_output` controls the output file name. 