### PR TITLE
User Callable Function For Activation And Cleanup

### DIFF
--- a/src/lib/utils/memory_resource_manager.cpp
+++ b/src/lib/utils/memory_resource_manager.cpp
@@ -19,6 +19,10 @@ boost::container::pmr::memory_resource* MemoryResourceManager::get_memory_resour
   return resource_pointer;
 }
 
+bool MemoryResourceManager::tracking_is_enabled() const {
+  return _tracking_is_enabled;
+}
+
 void MemoryResourceManager::enable_temporary_memory_tracking() {
   _tracking_is_enabled = true;
 }

--- a/src/lib/utils/memory_resource_manager.hpp
+++ b/src/lib/utils/memory_resource_manager.hpp
@@ -43,7 +43,7 @@ class MemoryResourceManager : public Noncopyable {
   MemoryResourceManager() = default;
 
   tbb::concurrent_vector<ResourceRecord> _memory_resources;
-  bool _tracking_is_enabled = true;
+  bool _tracking_is_enabled = false;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/memory_resource_manager.hpp
+++ b/src/lib/utils/memory_resource_manager.hpp
@@ -9,6 +9,8 @@
 
 namespace opossum {
 
+class MemoryTrackingPlugin;
+
 struct ResourceRecord {
   OperatorType operator_type;
   std::string operator_data_structure;
@@ -42,6 +44,7 @@ class MemoryResourceManager : public Noncopyable {
   // Make sure that only Hyrise (and tests) can create new instances.
   friend class Hyrise;
   friend class MemoryResourceManagerTest;
+  friend class MemoryTrackingPlugin;
   MemoryResourceManager() = default;
 
   tbb::concurrent_vector<ResourceRecord> _memory_resources;

--- a/src/lib/utils/memory_resource_manager.hpp
+++ b/src/lib/utils/memory_resource_manager.hpp
@@ -31,6 +31,8 @@ class MemoryResourceManager : public Noncopyable {
   // Disbales memory tracking. In this case, the MemoryResourceManager returns default MemoryResources.
   void disable_temporary_memory_tracking();
 
+  bool tracking_is_enabled() const;
+
   const tbb::concurrent_vector<ResourceRecord>& memory_resources() const;
 
   boost::container::pmr::memory_resource* get_memory_resource(const OperatorType operator_type,

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -35,7 +35,7 @@ add_plugin(NAME hyriseMvccDeletePlugin SRCS mvcc_delete_plugin.cpp mvcc_delete_p
 add_plugin(NAME hyriseSecondTestPlugin SRCS second_test_plugin.cpp second_test_plugin.hpp DEPS sqlparser)
 add_plugin(NAME hyriseTestPlugin SRCS test_plugin.cpp test_plugin.hpp DEPS sqlparser)
 add_plugin(NAME hyriseTestNonInstantiablePlugin SRCS non_instantiable_plugin.cpp)
-add_plugin(NAME memoryTrackingPlugin SRCS memory_tracking_plugin.cpp)
+add_plugin(NAME hyriseMemoryTrackingPlugin SRCS memory_tracking_plugin.cpp memory_tracking_plugin.hpp DEPS sqlparser)
 
 # We define TEST_PLUGIN_DIR to always load plugins from the correct directory for testing purposes
 add_definitions(-DTEST_PLUGIN_DIR="${CMAKE_BINARY_DIR}/lib/")

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -35,6 +35,7 @@ add_plugin(NAME hyriseMvccDeletePlugin SRCS mvcc_delete_plugin.cpp mvcc_delete_p
 add_plugin(NAME hyriseSecondTestPlugin SRCS second_test_plugin.cpp second_test_plugin.hpp DEPS sqlparser)
 add_plugin(NAME hyriseTestPlugin SRCS test_plugin.cpp test_plugin.hpp DEPS sqlparser)
 add_plugin(NAME hyriseTestNonInstantiablePlugin SRCS non_instantiable_plugin.cpp)
+add_plugin(NAME memoryTrackingPlugin SRCS memory_tracking_plugin.cpp)
 
 # We define TEST_PLUGIN_DIR to always load plugins from the correct directory for testing purposes
 add_definitions(-DTEST_PLUGIN_DIR="${CMAKE_BINARY_DIR}/lib/")

--- a/src/plugins/memory_tracking_plugin.cpp
+++ b/src/plugins/memory_tracking_plugin.cpp
@@ -1,0 +1,42 @@
+#include "memory_tracking_plugin.hpp"
+
+namespace opossum {
+
+std::string MemoryTrackingPlugin::description() const {
+  return "Activate and deactivate the tracking of temporary memory usage. Cleanup memory usage data.";
+}
+
+void MemoryTrackingPlugin::start() {}
+
+void MemoryTrackingPlugin::stop() {}
+
+std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> MemoryTrackingPlugin::provided_user_executable_functions()
+    const {
+  return {
+    {"is_enabled", [&]() { this->is_enabled(); }},
+    {"enable", [&]() { this->enable(); }},
+    {"disable", [&]() { this->disable(); }},
+    {"cleanup", [&]() { this->cleanup(); }}
+  };
+}
+
+bool MemoryTrackingPlugin::is_enabled() const { 
+  return _memory_resource_manager.tracking_is_enabled();
+}
+
+void MemoryTrackingPlugin::enable() const {
+  _memory_resource_manager.enable_temporary_memory_tracking();
+}
+
+void MemoryTrackingPlugin::disable() const {
+  _memory_resource_manager.disable_temporary_memory_tracking();
+  cleanup();
+}
+
+void MemoryTrackingPlugin::cleanup() const {
+  std::cout << "CLEANUP NOW" << std::endl;
+}
+
+EXPORT_PLUGIN(MemoryTrackingPlugin)
+
+}  // namespace opossum

--- a/src/plugins/memory_tracking_plugin.cpp
+++ b/src/plugins/memory_tracking_plugin.cpp
@@ -34,7 +34,12 @@ void MemoryTrackingPlugin::disable() const {
 }
 
 void MemoryTrackingPlugin::cleanup() const {
-  std::cout << "CLEANUP NOW" << std::endl;
+  // Calling clear on the vector has the effect that the desctructor is called for each ResourceRecord. This 
+  // invalidates the unique pointer to the TrackingMemoryResource stored there. Thus, the TrackingMemoryResource and
+  // its stored data are freed.
+  // TODO: confirm if this actually works.
+  _memory_resource_manager._memory_resources.clear();
+  _memory_resource_manager._memory_resources.shrink_to_fit();
 }
 
 EXPORT_PLUGIN(MemoryTrackingPlugin)

--- a/src/plugins/memory_tracking_plugin.hpp
+++ b/src/plugins/memory_tracking_plugin.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "hyrise.hpp"
+#include "utils/abstract_plugin.hpp"
+
+namespace opossum {
+
+class MemoryTrackingPlugin : public AbstractPlugin {
+ public:
+  MemoryTrackingPlugin() : _memory_resource_manager(Hyrise::get().memory_resource_manager) {}
+
+  std::string description() const final;
+
+  void start() final;
+
+  void stop() final;
+
+  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> provided_user_executable_functions() const final;
+
+  bool is_enabled() const;
+  void enable() const;
+  void disable() const;
+  void cleanup() const;
+
+ protected:
+  MemoryResourceManager& _memory_resource_manager;
+};
+
+}  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -264,6 +264,7 @@ set(
     gmock
     SQLite::SQLite3
     hyriseMvccDeletePlugin  # So that we can test member methods without going through dlsym
+    hyriseMemoryTrackingPlugin
 )
 
 # This warning does not play well with SCOPED_TRACE
@@ -279,7 +280,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Configure hyriseTest
 add_executable(hyriseTest ${HYRISE_UNIT_TEST_SOURCES})
-add_dependencies(hyriseTest hyriseSecondTestPlugin hyriseTestPlugin hyriseMvccDeletePlugin hyriseTestNonInstantiablePlugin)
+add_dependencies(hyriseTest hyriseSecondTestPlugin hyriseTestPlugin hyriseMvccDeletePlugin hyriseTestNonInstantiablePlugin hyriseMemoryTrackingPlugin)
 target_link_libraries(hyriseTest hyrise ${LIBRARIES})
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -235,6 +235,7 @@ set(
     lib/utils/size_estimation_utils_test.cpp
     lib/utils/string_utils_test.cpp
     plugins/mvcc_delete_plugin_test.cpp
+    plugins/memory_tracking_plugin_test.cpp
     testing_assert.cpp
     testing_assert.hpp
     utils/constraint_test_utils.hpp

--- a/src/test/lib/utils/memory_resource_manager_test.cpp
+++ b/src/test/lib/utils/memory_resource_manager_test.cpp
@@ -82,4 +82,12 @@ TEST_F(MemoryResourceManagerTest, ConcurrentCallsAreHandledCorrectly) {
   EXPECT_EQ(n_deallocated_bytes, -1 * expected_allocation_amount);
 }
 
+TEST_F(MemoryResourceManagerTest, EnablingAndDisablingWorks) {
+  ASSERT_TRUE(_memory_resource_manager.tracking_is_enabled());
+  _memory_resource_manager.disable_temporary_memory_tracking();
+  ASSERT_FALSE(_memory_resource_manager.tracking_is_enabled());
+  _memory_resource_manager.enable_temporary_memory_tracking();
+  ASSERT_TRUE(_memory_resource_manager.tracking_is_enabled());
+}
+
 }  // namespace opossum

--- a/src/test/plugins/memory_tracking_plugin_test.cpp
+++ b/src/test/plugins/memory_tracking_plugin_test.cpp
@@ -1,26 +1,50 @@
 #include "base_test.hpp"
 #include "hyrise.hpp"
 #include "utils/memory_resource_manager.hpp"
-#include "plugins/memory_tracking_plugin.hpp"
+#include "../../plugins/memory_tracking_plugin.hpp"
 
 namespace opossum {
 
 class MemoryTrackingPluginTest : public BaseTest {
  protected:
+  const MemoryTrackingPlugin _plugin{};
+  MemoryResourceManager* _memory_resource_manager;
+  void SetUp() override {
+    _memory_resource_manager = &Hyrise::get().memory_resource_manager;
+  }
   void TearDown() override {
     Hyrise::reset();
   }
 };
 
-TEST_F(MemoryTrackingPluginTest, EnableAndDisableWorks) {
-  // tracking should be disabled by default
-  ASSERT_FALSE(MemoryTrackingPlugin::is_enabled());
-  MemoryTrackingPlugin::enable();
-  ASSERT_TRUE(MemoryTrackingPlugin::is_enabled());
-  MemoryTrackingPlugin::disable();
-  ASSERT_FALSE(MemoryTrackingPlugin::is_enabled());
-  MemoryTrackingPlugin::enable();
-  ASSERT_TRUE(MemoryTrackingPlugin::is_enabled());
+TEST_F(MemoryTrackingPluginTest, EnableAndDisableNoAllocations) {
+  // Tracking should be disabled by default.
+  ASSERT_FALSE(_plugin.is_enabled());
+  ASSERT_FALSE(_memory_resource_manager->tracking_is_enabled());
+  _plugin.enable();
+  ASSERT_TRUE(_plugin.is_enabled());
+  ASSERT_TRUE(_memory_resource_manager->tracking_is_enabled());
+  _plugin.disable();
+  ASSERT_FALSE(_plugin.is_enabled());
+  ASSERT_FALSE(_memory_resource_manager->tracking_is_enabled());
+  _plugin.enable();
+  ASSERT_TRUE(_plugin.is_enabled());
+  ASSERT_TRUE(_memory_resource_manager->tracking_is_enabled());
+}
+
+TEST_F(MemoryTrackingPluginTest, AllocationsTrackedAfterEnable) {
+  // Allocations should not be tracked before the enable function is called.
+  const auto mem_resource_1 = _memory_resource_manager->get_memory_resource(OperatorType::Mock, "test_data_structure");
+  mem_resource_1->allocate(10);
+  mem_resource_1->allocate(20);
+  ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 0);
+  
+  // After tracking is enabled, allocations should be tracked.
+  _plugin.enable();
+  const auto mem_resource_2 = _memory_resource_manager->get_memory_resource(OperatorType::Mock, "test_data_structure");
+  mem_resource_2->allocate(10);
+  mem_resource_2->allocate(20);
+  ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 1);
 }
 
 }  // namespace opossum

--- a/src/test/plugins/memory_tracking_plugin_test.cpp
+++ b/src/test/plugins/memory_tracking_plugin_test.cpp
@@ -1,0 +1,26 @@
+#include "base_test.hpp"
+#include "hyrise.hpp"
+#include "utils/memory_resource_manager.hpp"
+#include "plugins/memory_tracking_plugin.hpp"
+
+namespace opossum {
+
+class MemoryTrackingPluginTest : public BaseTest {
+ protected:
+  void TearDown() override {
+    Hyrise::reset();
+  }
+};
+
+TEST_F(MemoryTrackingPluginTest, EnableAndDisableWorks) {
+  // tracking should be disabled by default
+  ASSERT_FALSE(MemoryTrackingPlugin::is_enabled());
+  MemoryTrackingPlugin::enable();
+  ASSERT_TRUE(MemoryTrackingPlugin::is_enabled());
+  MemoryTrackingPlugin::disable();
+  ASSERT_FALSE(MemoryTrackingPlugin::is_enabled());
+  MemoryTrackingPlugin::enable();
+  ASSERT_TRUE(MemoryTrackingPlugin::is_enabled());
+}
+
+}  // namespace opossum

--- a/src/test/plugins/memory_tracking_plugin_test.cpp
+++ b/src/test/plugins/memory_tracking_plugin_test.cpp
@@ -47,4 +47,30 @@ TEST_F(MemoryTrackingPluginTest, AllocationsTrackedAfterEnable) {
   ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 1);
 }
 
+TEST_F(MemoryTrackingPluginTest, Cleanup) {
+  _plugin.enable();
+  const auto mem_resource_1 = _memory_resource_manager->get_memory_resource(OperatorType::Mock, "test_data_structure");
+  const auto mem_resource_2 = _memory_resource_manager->get_memory_resource(OperatorType::Mock, "test_data_structure");
+  mem_resource_1->allocate(10);
+  mem_resource_1->allocate(20);
+  mem_resource_2->allocate(30);
+
+  ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 2);
+
+  _plugin.cleanup();
+  ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 0);
+}
+
+TEST_F(MemoryTrackingPluginTest, DisablePerformsCleanup) {
+  _plugin.enable();
+  const auto mem_resource = _memory_resource_manager->get_memory_resource(OperatorType::Mock, "test_data_structure");
+  mem_resource->allocate(10);
+
+  ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 1);
+
+  _plugin.disable();
+  ASSERT_EQ(_memory_resource_manager->memory_resources().size(), 0);
+  ASSERT_EQ(_memory_resource_manager->memory_resources().capacity(), 0);
+}
+
 }  // namespace opossum


### PR DESCRIPTION
**[This PR is currently in draft state. Find remaining TODOs below]**

## Description
This PR introduces a plugin with user callable functions to enable and disable the memory tracking and to cleanup tracking data. 

## Open Questions:
- Does the current cleanup approach actually free all memory (including the memory timeseries data)?
- Does the plugin need to be registered anywhere? Do we need to touch some plugin manager or plugin list or similar?

## Remaining TODOs
- Manual validation in the hyrise console
- automated end-to-end test with the following flow: (1) activate plugin through SQL, (2) perform some joins, (3) check that the meta table contains data, (4) deactivate the tracking, (5) check that the meta table is empty.